### PR TITLE
Makefile: fixed wrong installation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ usage:
 
 install:
 	install -d $(DESTDIR)/usr/bin
-	install -m 0755 $(TARGET) $(DESTDIR)/usr/bin
+	install -m 0755 $(TARGETDIR)/$(TARGET) $(DESTDIR)/usr/bin
 
 # Pull in dependency info for *existing* .o files
 -include $(OBJECTS:.$(OBJEXT)=.$(DEPEXT))


### PR DESCRIPTION
The install rule was trying to get the target executable from the wrong folder. This patch fixes this bug by addition of the "TARGETDIR" to the used source path in the 'install' directive.